### PR TITLE
Updated Paper Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This repository contains information related to the tool GraPacc presented in the Proceedings of the 34th International Conference on Software Engineering, 2012. The tool was originally presented in [this paper](http://delivery.acm.org.prox.lib.ncsu.edu/10.1145/2340000/2337431/p1407-nguyen.pdf?ip=152.14.136.96&id=2337431&acc=ACTIVE%20SERVICE&key=6ABC8B4C00F6EE47%2E4D4702B0C3E38B35%2E4D4702B0C3E38B35%2E4D4702B0C3E38B35&CFID=717070204&CFTOKEN=90488387&__acm__=1443399999_cc300c8059c142178607b1e8eceeb9a9).
+This repository contains information related to the tool GraPacc presented in the Proceedings of the 34th International Conference on Software Engineering, 2012. The tool was originally presented in [this paper](http://dl.acm.org/citation.cfm?id=2337431#).
 
 This repository _is not_ the original repository for this tool. Here are some links to the original project:
 


### PR DESCRIPTION
The previous link was accessed via the proxy server and no longer worked. This link should take the user to the ACM Digital Library. Close #13 
